### PR TITLE
fix ConcurrentSum, bench test is equity

### DIFF
--- a/concurrencyslower.go
+++ b/concurrencyslower.go
@@ -89,12 +89,13 @@ func ConcurrentSum() int {
 			// Split the "input" into n chunks that do not overlap.
 			start := (limit / n) * i
 			end := start + (limit / n)
+			s := 0
 
 			// Run the loop over the given chunk.
 			for j := start; j < end; j += 1 {
-				sums[i] += j
+				s += j
 			}
-
+			sums[i] = s
 			// Tell the `WaitGroup` that this goroutine has completet its task.
 			wg.Done()
 		}(i)


### PR DESCRIPTION
my MacBook Pro bench test:
goos: darwin
goarch: amd64
pkg: test/c2
BenchmarkSerialSum-8       	       1	4067272947 ns/op
BenchmarkConcurrentSum-8   	       2	 838796771 ns/op
BenchmarkChannelSum-8      	       2	 829172200 ns/op
PASS
ok  	test/c2	9.113s